### PR TITLE
Add Divine Cities trilogy to books read

### DIFF
--- a/wiki/books/books-read.md
+++ b/wiki/books/books-read.md
@@ -2,6 +2,18 @@
 layout: wikibook
 title: A running list of books I've finished
 books:
+ - title: City of Stairs
+   author: Robert Jackson Bennett
+   link: https://openlibrary.org/isbn/9780804137171
+   image: https://covers.openlibrary.org/b/isbn/9780804137171-L.jpg
+ - title: City of Blades
+   author: Robert Jackson Bennett
+   link: https://openlibrary.org/isbn/9780553419719
+   image: https://covers.openlibrary.org/b/isbn/9780553419719-L.jpg
+ - title: City of Miracles
+   author: Robert Jackson Bennett
+   link: https://openlibrary.org/isbn/9780553419733
+   image: https://covers.openlibrary.org/b/isbn/9780553419733-L.jpg
  - title: Lost Book of Adana Moreau
    author: Michael Zapata
    link: https://openlibrary.org/works/OL21971248W

--- a/wiki/books/books-read.md
+++ b/wiki/books/books-read.md
@@ -6,14 +6,18 @@ books:
    author: Robert Jackson Bennett
    link: https://openlibrary.org/isbn/9780804137171
    image: https://covers.openlibrary.org/b/isbn/9780804137171-L.jpg
+   date_finished: 11/16/2025
+   notes: Absolutely magic series. Deeply developed characters, totally novel world mechanic and tons of lore. Loved every second of it.
  - title: City of Blades
    author: Robert Jackson Bennett
    link: https://openlibrary.org/isbn/9780553419719
    image: https://covers.openlibrary.org/b/isbn/9780553419719-L.jpg
+   date_finished: 12/03/2025
  - title: City of Miracles
    author: Robert Jackson Bennett
    link: https://openlibrary.org/isbn/9780553419733
    image: https://covers.openlibrary.org/b/isbn/9780553419733-L.jpg
+   date_finished: 12/21/2025
  - title: Lost Book of Adana Moreau
    author: Michael Zapata
    link: https://openlibrary.org/works/OL21971248W


### PR DESCRIPTION
## What changed

- Added *City of Stairs*, *City of Blades*, and *City of Miracles* by Robert Jackson Bennett to the books-read page.
- Added Open Library links and cover images for each book.
- Added finish dates spanning November–December 2025.
- Added the series review to *City of Stairs* only.

## Impact

The full Divine Cities trilogy will appear on the books-read page once this PR is merged.

## Validation

- Confirmed the diff changes only `wiki/books/books-read.md`.
- Confirmed the expected titles, author, dates, links, images, and review are present in the page front matter.