### PR TITLE
Fix Buttondown subscription forms

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -48,14 +48,13 @@
         </p>
   
         <form
-  action="https://buttondown.email/api/emails/embed-subscribe/tomcritchlow"
+  action="https://buttondown.com/api/emails/embed-subscribe/tomcritchlow"
   method="post"
-  target="popupwindow"
-  onsubmit="window.open('https://newsletter.tomcritchlow.com', 'popupwindow')"
   class="embeddable-buttondown-form"
 >
-  <input type="email" name="email" id="bd-email" placeholder="Email Address" class="mw-100 w-100 w5-ns f5 input-reset ba b--black-20 pv3 ph3 border-box"/>
+  <input type="email" required autocomplete="email" name="email" id="bd-email" placeholder="Email Address" class="mw-100 w-100 w5-ns f5 input-reset ba b--black-20 pv3 ph3 border-box"/>
   <input type="hidden" name="metadata__cta" value="footer">
+  <input type="hidden" value="1" name="embed" />
   <input type="submit" value="Subscribe" class="input-reset w-100 w-auto-ns bg-black-80 white f5 pv2 pv3-ns ph4 ba b--black-80 bg-hover-mid-gray"/>
   
 </form>

--- a/_layouts/blog-2023.html
+++ b/_layouts/blog-2023.html
@@ -54,9 +54,10 @@
         
     <div class="bt b--black-10 mt3">
       <p>This post was written by Tom Critchlow - blogger and independent consultant. Subscribe to join my occassional newsletter:</p>
-        <form action="https://buttondown.email/api/emails/embed-subscribe/tomcritchlow" method="post" target="popupwindow" onsubmit="window.open('https://buttondown.email/tomcritchlow', 'popupwindow')" class="embeddable-buttondown-form flex items-center w-100 f5">
-            <input placeholder="Email Address" type="email" name="email" id="bd-email" class="bg-light-gray w-100 input-reset ba b--black-20 pv2 ph3 border-box br2 br--left">
+        <form action="https://buttondown.com/api/emails/embed-subscribe/tomcritchlow" method="post" class="embeddable-buttondown-form flex items-center w-100 f5">
+            <input placeholder="Email Address" type="email" required autocomplete="email" name="email" id="bd-email" class="bg-light-gray w-100 input-reset ba b--black-20 pv2 ph3 border-box br2 br--left">
             <input type="hidden" name="metadata__cta" value="blogend">
+            <input type="hidden" value="1" name="embed" />
             <input type="submit" value="Subscribe" class="input-reset w-auto-ns pv2 ph3 ba b--newgreen bg-light-gray br2 br--right pointer">
             </form>
     </div>

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -47,9 +47,10 @@
         
     <div class="bt b--black-10 mt3">
       <p>This post was written by Tom Critchlow - blogger and independent consultant. Subscribe to join my occassional newsletter:</p>
-        <form action="https://buttondown.email/api/emails/embed-subscribe/tomcritchlow" method="post" target="popupwindow" onsubmit="window.open('https://buttondown.email/tomcritchlow', 'popupwindow')" class="embeddable-buttondown-form flex items-center w-100 f5">
-            <input placeholder="Email Address" type="email" name="email" id="bd-email" class="bg-light-gray w-100 input-reset ba b--black-20 pv2 ph3 border-box br2 br--left">
+        <form action="https://buttondown.com/api/emails/embed-subscribe/tomcritchlow" method="post" class="embeddable-buttondown-form flex items-center w-100 f5">
+            <input placeholder="Email Address" type="email" required autocomplete="email" name="email" id="bd-email" class="bg-light-gray w-100 input-reset ba b--black-20 pv2 ph3 border-box br2 br--left">
             <input type="hidden" name="metadata__cta" value="blogend">
+            <input type="hidden" value="1" name="embed" />
             <input type="submit" value="Subscribe" class="input-reset w-auto-ns pv2 ph3 ba b--newgreen bg-light-gray br2 br--right pointer">
             </form>
     </div>

--- a/_layouts/strategy-home.html
+++ b/_layouts/strategy-home.html
@@ -62,14 +62,13 @@ footer{
     <p>So I'm writing a book - serialized free online - about the art and science of independent consulting. Available in print early 2024.</p>
 
     <form
-  action="https://buttondown.email/api/emails/embed-subscribe/tomcritchlow"
+  action="https://buttondown.com/api/emails/embed-subscribe/tomcritchlow"
   method="post"
-  target="popupwindow"
-  onsubmit="window.open('https://newsletter.tomcritchlow.com', 'popupwindow')"
   class="embeddable-buttondown-form f5 helvetica"
 >
 <div class="red i pb2">Sign up to get notified of new chapters</div>
-  <input type="email" name="email" placeholder="Your Email Address" id="bd-email" class="input-reset ba b--black-10 fl black-80 bg-white pa2 pv3 lh-solid w-70 w-75-m w-70-l br2-ns br--left-ns"/>
+  <input type="email" required autocomplete="email" name="email" placeholder="Your Email Address" id="bd-email" class="input-reset ba b--black-10 fl black-80 bg-white pa2 pv3 lh-solid w-70 w-75-m w-70-l br2-ns br--left-ns"/>
+  <input type="hidden" value="1" name="embed" />
   <input type="submit" value="Subscribe" class="button-reset fl pv3 tc ba b--black-10 bg-animate bg-green hover-bg-dark-green white pointer w-30 w-25-m w-30-l br2-ns br--right-ns"/>
   
 </form>

--- a/_layouts/tsi-chapter.html
+++ b/_layouts/tsi-chapter.html
@@ -333,9 +333,10 @@ details[open] summary:after {
         <div class="pt3 pb4 pt3-l pb0-l b--bookgreen-20 z-1">
 
             <div class="f6 black-60 i pb2">Sign up to get notified of new chapters</div>
-            <form action="https://buttondown.email/api/emails/embed-subscribe/tomcritchlow" method="post" target="popupwindow" onsubmit="window.open('https://buttondown.email/tomcritchlow', 'popupwindow')" class="embeddable-buttondown-form flex items-center w-100 f6 helvetica">
-              <input placeholder="Email Address" type="email" name="email" id="bd-email" class="bg-white w-100 input-reset ba b--newgreen pv2 ph3 border-box br2 br--left">
+            <form action="https://buttondown.com/api/emails/embed-subscribe/tomcritchlow" method="post" class="embeddable-buttondown-form flex items-center w-100 f6 helvetica">
+              <input placeholder="Email Address" type="email" required autocomplete="email" name="email" id="bd-email" class="bg-white w-100 input-reset ba b--newgreen pv2 ph3 border-box br2 br--left">
               <input type="hidden" name="metadata__cta" value="homepage">
+              <input type="hidden" value="1" name="embed" />
               <input type="submit" value="Subscribe" class="input-reset w-auto-ns pv2 ph3 ba b--newgreen bg-washed-green br2 br--right pointer">
               </form>
         </div>

--- a/new-homepage4.html
+++ b/new-homepage4.html
@@ -104,14 +104,13 @@
 
         <p class="f6"><em>Join my newsletter:</em></p>
       <form
-      action="https://buttondown.email/api/emails/embed-subscribe/tomcritchlow"
+      action="https://buttondown.com/api/emails/embed-subscribe/tomcritchlow"
       method="post"
-      target="popupwindow"
-      onsubmit="window.open('https://buttondown.email/tomcritchlow', 'popupwindow')"
       class="embeddable-buttondown-form flex items-center w-100 f4-l f5"
     >
-      <input placeholder="Email Address" type="email" name="email" id="bd-email" class="w-100 input-reset ba b--black-20 pv3 ph4 border-box br2 br--left">
+      <input placeholder="Email Address" type="email" required autocomplete="email" name="email" id="bd-email" class="w-100 input-reset ba b--black-20 pv3 ph4 border-box br2 br--left">
       <input type="hidden" name="metadata__cta" value="homepage">
+      <input type="hidden" value="1" name="embed" />
       <input type="submit" value="Subscribe" class="input-reset w-auto-ns bg-newgreen white pv3 ph4 ba b--black-20 bg-hover-mid-gray br2 br--right pointer">
       </form>
         

--- a/new-homepage5.html
+++ b/new-homepage5.html
@@ -221,14 +221,13 @@
 
     <p class="f6 mw7 center"><em>Join my newsletter:</em></p>
   <form
-  action="https://buttondown.email/api/emails/embed-subscribe/tomcritchlow"
+  action="https://buttondown.com/api/emails/embed-subscribe/tomcritchlow"
   method="post"
-  target="popupwindow"
-  onsubmit="window.open('https://buttondown.email/tomcritchlow', 'popupwindow')"
   class="embeddable-buttondown-form flex items-center w-100 f4-l f5 mw7 center"
 >
-  <input placeholder="Email Address" type="email" name="email" id="bd-email" class="w-100 input-reset ba b--black-20 pv3 ph4 border-box br2 br--left">
+  <input placeholder="Email Address" type="email" required autocomplete="email" name="email" id="bd-email" class="w-100 input-reset ba b--black-20 pv3 ph4 border-box br2 br--left">
   <input type="hidden" name="metadata__cta" value="homepage">
+  <input type="hidden" value="1" name="embed" />
   <input type="submit" value="Subscribe" class="input-reset w-auto-ns bg-newgreen white pv3 ph4 ba b--black-20 bg-hover-mid-gray br2 br--right pointer">
   </form>
     


### PR DESCRIPTION
## What changed

- update all seven Buttondown forms to the current `buttondown.com` embed endpoint
- remove popup targets and `onsubmit` JavaScript so the browser follows Buttondown validation and CAPTCHA responses
- add Buttondown's required `embed=1` field
- mark email inputs as required and enable email autocomplete
- preserve existing styling and `metadata__cta` attribution

## Why

Buttondown warned that JavaScript-assisted submissions can prevent subscribers from completing CAPTCHA verification or correcting validation errors. The old forms opened a named popup during submission and used the legacy `buttondown.email` endpoint.

## Impact

Subscription attempts now use a standard browser form POST, matching Buttondown's supported integration. Successful submissions, validation errors, and CAPTCHA challenges can all follow Buttondown's normal response flow.

## Validation

- inspected the full commit diff
- confirmed all seven forms use the current endpoint
- confirmed all seven forms include `name="embed"`
- confirmed no updated form contains `popupwindow`, `target`, or submit-time JavaScript
- confirmed existing CTA metadata values remain intact